### PR TITLE
Support Shamir's threshold secret sharing

### DIFF
--- a/.github/workflows/lint-test-cover-docs.yml
+++ b/.github/workflows/lint-test-cover-docs.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           pip install -U .[lint,test]
           python -m pylint shamirs # Check against linting rules.
-          python -m pytest # Run tests.
+          python -m pytest -W ignore::UserWarning # Run tests.
       - name: Publish coverage results.
         run: |
           pip install -U .[coveralls]

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Testing and Conventions
 All unit tests are executed and their coverage is measured when using `pytest <https://docs.pytest.org>`__ (see ``setup.cfg`` for configuration details)::
 
     python -m pip install .[test]
-    python -m pytest
+    python -m pytest -W ignore::UserWarning
 
 Alternatively, all unit tests are included in the module itself and can be executed using `doctest <https://docs.python.org/3/library/doctest.html>`__::
 

--- a/shamirs/shamirs.py
+++ b/shamirs/shamirs.py
@@ -4,6 +4,7 @@ Minimal pure-Python implementation of
 """
 from __future__ import annotations
 import doctest
+import warnings
 from typing import Union, Optional, Sequence
 from collections.abc import Iterable
 import base64
@@ -140,6 +141,11 @@ def shares(
       ...
     ValueError: prime modulus must be at least 2
 
+    It is allowed to ask for fewer shares than needed to reconstruct, but the library will raise a
+    warning: UserWarning: quantity of shares should be at least the threshold to be reconstructable.
+    >>> len(shares(1, 3, 11, 7))
+    3
+
     One may also ask for a larger set of shares than necessary to later reconstruct.
     >>> len(shares(1, 7, 11, 3))
     7
@@ -171,6 +177,8 @@ def shares(
 
     # Use the maximum threshold if one is not specified.
     threshold = threshold or quantity
+    if threshold > quantity:
+        warnings.warn('quantity of shares should be at least the threshold to be reconstructable')
 
     # Use a default prime value if one is not specified.
     prime = (2 ** 127) - 1 if prime is None else prime

--- a/shamirs/shamirs.py
+++ b/shamirs/shamirs.py
@@ -188,12 +188,16 @@ def shares(
 
     # Compute each share value such that ``shares[i] = f(i)`` if the polynomial
     # is ``f``.
-    shares_ = []
-    for i in range(quantity):
-        shares_.append(coefficients[0])
-        for j in range(1, len(coefficients)):
-            shares_[i] = (shares_[i] + coefficients[j] * pow(i + 1, j)) % prime
-        shares_[i] = share((shares_[i] * (2 ** 32)) + i)
+    shares_ = [
+        sum(
+            c_j * i ** j % prime
+            for j, c_j in enumerate(coefficients)
+        ) % prime
+        for i in range(1, quantity+1)
+    ]
+
+    # Embed each shares index (x-coordinate) by shifting right and using the new lowest 32-bits.
+    shares_ = [share((share_ * (2 ** 32)) + i) for i, share_ in enumerate(shares_)]
 
     return shares_
 


### PR DESCRIPTION
This pull request is dependent on [a feature](https://github.com/lapets/lagrange/issues/1) in the `lagrange` library being merged first.  These changes are backwards-compatible and the share format is remains unchanged.

```python
>>> shares = shamirs.shares(value=123, quantity=20, prime=4567, threshold=12)
>>> subset_of_shares = shares[8:]  # use the last twelve shares
>>> shamirs.interpolate(subset_of_shares, prime=4567, threshold=12)
123
```

See the documentation for more examples, warning and error cases.